### PR TITLE
full path to /bin/cat

### DIFF
--- a/scripts/dwr
+++ b/scripts/dwr
@@ -19,7 +19,7 @@ declare repo hostname
 
 jqscript() {
 
-  cat << EOF
+  /bin/cat << EOF
       def symbol:
         sub("skipped"; "SKIP") |
         sub("success"; "GOOD") |


### PR DESCRIPTION
It forces the correct cat command if anybody has an alias of the `cat` command, eg. to the `bat` command or something similar.