### PR TITLE
bugfix jq null values

### DIFF
--- a/scripts/dwr
+++ b/scripts/dwr
@@ -21,6 +21,7 @@ jqscript() {
 
   cat << EOF
       def symbol:
+        sub(""; "")? // "NULL" |
         sub("skipped"; "SKIP") |
         sub("success"; "GOOD") |
         sub("failure"; "FAIL");


### PR DESCRIPTION
It fixes `jq: error (at <stdin>:0): null (null) cannot be matched, as it is not a string` crash.